### PR TITLE
Fix deprecation warnings on Rails 3.1

### DIFF
--- a/lib/graticule/geocoder/bogus.rb
+++ b/lib/graticule/geocoder/bogus.rb
@@ -7,7 +7,7 @@ module Graticule #:nodoc:
       self.responses = []
       
       # A default location to use if the responses queue is empty
-      class_inheritable_accessor :default
+      class_attribute :default
       
       def locate(address)
         responses.shift || default || Location.new(:street => address)


### PR DESCRIPTION
Commit d6df6b62cb missed one class_inheritable_accessor to class_attribute change, fixes deprecation warnings on Rails 3.1
