### PR TITLE
Support for Google geocoder doesn't handle localities returned as "DependentLocality"

### DIFF
--- a/lib/graticule/geocoder/google.rb
+++ b/lib/graticule/geocoder/google.rb
@@ -56,6 +56,7 @@ module Graticule #:nodoc:
 
         with_options :deep => true, :namespace => 'urn:oasis:names:tc:ciq:xsdschema:xAL:2.0' do |map|
           map.element :street,      String, :tag => 'ThoroughfareName'
+          map.element :dep_locality,String, :tag => 'DependentLocalityName'
           map.element :locality,    String, :tag => 'LocalityName'
           map.element :region,      String, :tag => 'AdministrativeAreaName'
           map.element :postal_code, String, :tag => 'PostalCodeNumber'
@@ -92,7 +93,7 @@ module Graticule #:nodoc:
           :latitude    => result.latitude,
           :longitude   => result.longitude,
           :street      => result.street,
-          :locality    => result.locality,
+          :locality    => result.locality || result.dep_locality,
           :region      => result.region,
           :postal_code => result.postal_code,
           :country     => result.country,


### PR DESCRIPTION
Some cities in my region are no longer being recognized and returned by Graticule:

"Hamilton, Ontario, Canada"
"Stoney Creek, Ontario, Canada"

geocoder = Graticule.service(:google).new mykey
geocoder.locate "Toronto, Ontario, Canada"
=> Toronto, ON CA 
geocoder.locate "Hamilton, Ontario, Canada"
=> ON CA 
geocoder.locate "Stoney Creek, Ontario, Canada"
=> ON CA
If you perform the queries directly yourself using the "http://maps.google.com/maps/geo" url, you'll see that the missing locality names are identified and returned in the response but they are present in a "DependentLocality" key instead of the usual "Locality" key.

This just started happening recently for the cities mentioned above. I don't know how long Google has been using "DependentLocality" in general.
