### PR TITLE
I accidentally left this debugging code in when I updated google to v3

### DIFF
--- a/lib/graticule/geocoder/base.rb
+++ b/lib/graticule/geocoder/base.rb
@@ -81,7 +81,6 @@ module Graticule #:nodoc:
         check_error(response)
         return parse_response(response)
       rescue OpenURI::HTTPError => e
-        raise e.inspect
         check_error(prepare_response(e.io.read))
         raise
       end


### PR DESCRIPTION
This was causing some problems for me when I was trying to rescue the OpenURI::Error but it wasn't actually being raised anymore. Then I discovered it was my fault, and I feel bad.
