### PR TITLE
Small tweak that gives some love to sublocalities

### DIFF
--- a/lib/graticule/geocoder/google.rb
+++ b/lib/graticule/geocoder/google.rb
@@ -44,8 +44,8 @@ module Graticule #:nodoc:
                 @street_number = component["short_name"]
               when "route"
                 @route = component["short_name"]
-              when "locality"
-                @locality = component["long_name"]
+              when "locality", "sublocality"
+                @locality = component["long_name"] 
               when "administrative_area_level_1"
                 @region = component["short_name"]
               when "country"


### PR DESCRIPTION
We have been doing a lot of geocoding in the New York area and noticed that some services ( Google Maps ) did not return any information about locality if the address was in Brooklyn or Queens. ( In other words, the city would be blank ).

For example ( Geocoding::GEOCODER is an instance of Graticule.service, using Google ):

2.0.0 :003 > Geocoding::GEOCODER.locate( "200 Eastern Parkway" ) //this is in brooklyn

 => Graticule::Location:0x0000000b5c3a40 @latitude=40.670255, @longitude=-73.95742899999999, @street="200 Eastern Pkwy", @locality=nil, @region="NY", @postal_code="11225", @country="US", @precision=#<Graticule::Precision:0x0000000b5c3428 @name=:address

WIth this small patch, it will correctly return:

 => Graticule::Location:0x00000007fe5c48 @latitude=40.671151, @longitude=-73.96347659999999, @street="200 Eastern Pkwy", @locality="Brooklyn", @region="NY", @postal_code="11238", @country="US", @precision=#<Graticule::Precision:0x00000007fe5298 @name=:address

I'm not sure that Google will report back a locality if a sub-locality is found, In most cases you want to know the sub-locality anyway, as it generally specifies a borough or other region that may appear on a mailing address, and residents probably identify with it more directly rather than the encompassing locality.

If there are cases where Google will report back both ( we have not found any ), then perhaps a better fix would be to have a :sublocality attr_accessor and store the result from Google there. 

Decided to make a PR to get the juices flowing. Thanks for the work!
