### PR TITLE
Add now-required username to Geonames.new

### DIFF
--- a/lib/graticule/geocoder/geonames.rb
+++ b/lib/graticule/geocoder/geonames.rb
@@ -3,12 +3,13 @@ module Graticule #:nodoc:
   module Geocoder #:nodoc:
     class Geonames < Base
 
-      def initialize
+      def initialize(username = nil)
         @url = URI.parse 'http://ws.geonames.org/timezone'
+        @username = username
       end
 
       def time_zone(location)
-        get :formatted => 'true', :style => 'full', :lat => location.latitude, :lng => location.longitude
+        get :formatted => 'true', :style => 'full', :lat => location.latitude, :lng => location.longitude, :username => @username
       end
 
     private

--- a/lib/graticule/geocoder/mapquest.rb
+++ b/lib/graticule/geocoder/mapquest.rb
@@ -114,8 +114,11 @@ module Graticule #:nodoc:
         )
       end
 
-      # Extracts and raises any errors in +xml+
-      def check_error(xml) #:nodoc
+      # raises any errors
+      def check_error(response)
+        if response.result.locations.addresses.blank?
+          raise AddressError, 'unknown address'
+        end
       end
 
     end


### PR DESCRIPTION
...because our hits to Graticule::Geocoder::Geonames.new.time_zone(...) get Graticule::Error: unknown error Please add a username to each call in order for geonames to be able to identify the calling application and count the credits usage.